### PR TITLE
build(docker): specify entrypoint instead of cmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM openjdk:11-jdk-slim
 
 COPY build/libs/kafka-processor-cosmos-block-*-standalone.jar /opt/kafka-processor-cosmos-block.jar
 
-CMD ["java","-jar","/opt/kafka-processor-cosmos-block.jar"]
+ENTRYPOINT ["java","-jar","/opt/kafka-processor-cosmos-block.jar"]


### PR DESCRIPTION
Finally better to specify an `ENTRYPOINT` than a `CMD` 😉 