### PR TITLE
Fix: Error queue always active

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ COPY --from=build /usr/src/app/build/*-runner /work/application
 
 EXPOSE 8080
 
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,6 +10,6 @@ kafka-streams.metadata.max.age.ms=500
 kafka-streams.auto.offset.reset=earliest
 kafka-streams.metrics.recording.level=DEBUG
 
-topic.in=$TOPIC_IN
-topic.out=$TOPIC_OUT
-topic.error=$TOPIC_ERROR
+topic.in=in
+topic.out=out
+topic.error=


### PR DESCRIPTION
Error topic was always active because of the default value set in the `application.properties`.
The Dockerfile was also using `CMD` instead of the more usual `ENTRYPOINT`.