### PR TITLE
ci(release): inherit secrets when calling child workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,17 @@ jobs:
   lint:
     if: github.ref == 'refs/heads/main' && github.actor == 'bot-anik'
     uses: ./.github/workflows/lint.yml
+    secrets: inherit
 
   build:
     if: github.ref == 'refs/heads/main' && github.actor == 'bot-anik'
     uses: ./.github/workflows/build.yml
+    secrets: inherit
 
   test:
     if: github.ref == 'refs/heads/main' && github.actor == 'bot-anik'
     uses: ./.github/workflows/test.yml
+    secrets: inherit
 
   perfom-release:
     if: github.ref == 'refs/heads/main' && github.actor == 'bot-anik'


### PR DESCRIPTION
This options shouldn't be needed, but for a reason I ignore the release doesn't work..

My mindset around this is: Let's try it, because I have no other idea.