### PR TITLE
Fix: optional error topic

### DIFF
--- a/src/test/kotlin/com/okp4/processor/cosmos/TopologyTest.kt
+++ b/src/test/kotlin/com/okp4/processor/cosmos/TopologyTest.kt
@@ -13,6 +13,7 @@ import org.apache.kafka.streams.StreamsConfig
 import org.apache.kafka.streams.TopologyTestDriver
 import tendermint.types.BlockOuterClass.Block
 import tendermint.types.Types
+import java.util.*
 import kotlin.random.Random.Default.nextBytes
 
 fun List<TxOuterClass.Tx>.wrapIntoBlock(height: Long): Block = Block.newBuilder().setHeader(
@@ -48,7 +49,7 @@ class TopologyTest : BehaviorSpec({
         val topologyProducer = TopologyProducer().apply {
             topicIn = "in"
             topicOut = "out"
-            topicError = "error"
+            topicError = Optional.of("error")
         }
 
         val testDriver = TopologyTestDriver(topologyProducer.buildTopology(), config)


### PR DESCRIPTION
An error can be raised by Quarkus when an optional value is set by using nullable type.
Fixed by using Java Optional type.